### PR TITLE
Release 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Depthai Viewer changelog
 
+## 0.2.6
+- Fix regression: Without an active stereo config the viewer would crash
+
 ## 0.2.5
 - Fixed depth aligned camera streams not being rectified and undistorted. Resulting in misaligned visualisation.
 

--- a/rerun_py/depthai_viewer/_backend/device.py
+++ b/rerun_py/depthai_viewer/_backend/device.py
@@ -508,8 +508,9 @@ class Device:
 
         # Make sure that it's possible to create stereo depth
         try:
-            stereo_pair = config.stereo.stereo_pair
-            self._oak.device.readCalibration2().getCameraExtrinsics(stereo_pair[0], stereo_pair[1])
+            if config.stereo:
+                stereo_pair = config.stereo.stereo_pair
+                self._oak.device.readCalibration2().getCameraExtrinsics(stereo_pair[0], stereo_pair[1])
         except RuntimeError:
             config.stereo = None
         if config.stereo:


### PR DESCRIPTION
## 0.2.6
- Fix regression: Without an active stereo config the viewer would crash